### PR TITLE
修复在iOS中文输入法下偶尔会接受到拼音到参数

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3299,9 +3299,9 @@
       "dev": true
     },
     "@tinymce/tinymce-vue": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-vue/-/tinymce-vue-3.2.2.tgz",
-      "integrity": "sha512-LNgKbdaScHHkBsq6UZsMpEL5yPY8oYTGaOX97+ArpJSw4B6KSQpKU+/GHnkytQhPgQLLob+ghejP0ifVQXuczg=="
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-vue/-/tinymce-vue-3.2.8.tgz",
+      "integrity": "sha512-jEz+NZ0g+FZFz273OEUWz9QkwPMyjc5AJYyxOgu51O1Y5UaJ/6IUddXTX6A20mwCleEv5ebwNYdalviafx4fnA=="
     },
     "@types/babel-types": {
       "version": "7.0.7",
@@ -18004,9 +18004,9 @@
       "dev": true
     },
     "tinymce": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.3.2.tgz",
-      "integrity": "sha512-d8LaanlW+i/V5Ncb49gR2ncx0Tl2iWJBsepdsuT5qOlFaAPueIfc+btwwERXra7M6KDx0mOwKJaE2FBI+lHz3Q=="
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.6.2.tgz",
+      "integrity": "sha512-z7zvM5seOPiW86/vqf08kStwW5Zs5U9oQfuqh2rTj4jEcT2QzxT0v72i2zw3W6rbTLldkAej6edFZphj5ee5zg=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "@belvoly-vue-aioa/bvant": "^0.1.12",
-    "@tinymce/tinymce-vue": "^3.2.0",
+    "@tinymce/tinymce-vue": "^3.2.8",
     "axios": "^0.19.2",
     "core-js": "^3.6.4",
     "element-ui": "^2.13.0",
-    "tinymce": "^5.2.1",
+    "tinymce": "^5.6.2",
     "vue": "^2.6.11",
     "vue-router": "^3.1.6"
   },

--- a/packages/tinymce/Editor.vue
+++ b/packages/tinymce/Editor.vue
@@ -4,6 +4,7 @@
 
 <script>
 import tinymce from 'tinymce/tinymce' // 配置富文本
+import 'tinymce/icons/default'
 import 'tinymce/themes/silver/theme' // 引入富文本的主要脚本
 import Editor from '@tinymce/tinymce-vue' // 引用富文本组件
 // import skin_url from "../../../public/static/tinymce/skins/ui/oxide/skin.min.css" // 富文本样式

--- a/packages/tinymce/README.md
+++ b/packages/tinymce/README.md
@@ -1,4 +1,6 @@
-
+## v 0.2.0
+1. 修复在iOS中文输入法下偶尔会接受到拼音到参数
+2. 更新tinymce版本，更好到支持移动端
 ## v 0.1.9
 1. 增加移动端在获得焦点和失去焦点时增加keyboardShow、keyboardHide事件
 2. 修复Vue toolbar属性 object类型不对错误

--- a/packages/tinymce/package.json
+++ b/packages/tinymce/package.json
@@ -13,8 +13,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@tinymce/tinymce-vue": "3.2.0",
-    "tinymce": "5.2.2"
+    "@tinymce/tinymce-vue": "3.2.8",
+    "tinymce": "5.6.2"
   },
   "devDependencies": {
     "rollup-plugin-commonjs": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1728,9 +1728,10 @@
     error-stack-parser "^2.0.0"
     string-width "^2.0.0"
 
-"@tinymce/tinymce-vue@3.2.0", "@tinymce/tinymce-vue@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@tinymce/tinymce-vue/-/tinymce-vue-3.2.0.tgz#abadab7fd6e143688e756df779fc3b81e586427a"
+"@tinymce/tinymce-vue@3.2.8", "@tinymce/tinymce-vue@^3.2.8":
+  version "3.2.8"
+  resolved "https://registry.yarnpkg.com/@tinymce/tinymce-vue/-/tinymce-vue-3.2.8.tgz#014571b52ec8fa83665a7fa887bf65140207de71"
+  integrity sha512-jEz+NZ0g+FZFz273OEUWz9QkwPMyjc5AJYyxOgu51O1Y5UaJ/6IUddXTX6A20mwCleEv5ebwNYdalviafx4fnA==
 
 "@types/babel-types@*", "@types/babel-types@^7.0.0":
   version "7.0.7"
@@ -10430,9 +10431,10 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
 
-tinymce@5.2.2, tinymce@^5.2.1:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-5.2.2.tgz#1ac77cce1565b54932b4e612d2fd9c07b687f238"
+tinymce@5.6.2, tinymce@^5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/tinymce/-/tinymce-5.6.2.tgz#4c20c22e328c5d0baab204928dbc2b0ecbed18b4"
+  integrity sha512-z7zvM5seOPiW86/vqf08kStwW5Zs5U9oQfuqh2rTj4jEcT2QzxT0v72i2zw3W6rbTLldkAej6edFZphj5ee5zg==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
1. 修复在iOS中文输入法下偶尔会接受到拼音到参数
2. 更新tinymce版本，更好到支持移动端